### PR TITLE
Clarified what is returned by Active Grants

### DIFF
--- a/docs/tables/turbot_active_grant.md
+++ b/docs/tables/turbot_active_grant.md
@@ -1,6 +1,8 @@
 # Table: turbot_active_grant
 
-A active grant is the assignment of a permission to a Turbot user or group on a resource or resource group which is active. 
+An active grant is the assignment of a permission to a Turbot user or group on a resource or resource group which is active.  
+
+The `turbot_active_grant` table will only return active grants.  Use the `turbot_grant` table to get a list of all grants.
 
 ## Examples
 


### PR DESCRIPTION
Added a clarification that the `turbot_active_grants` table will only return rows for active grants.  Just wanted to make it explicit.

I found myself looking for a `grant_active` column or similar.  Such a column doesn't exist because only active grants are returned.
