### PR TITLE
Table turbot notification resource object

### DIFF
--- a/docs/tables/turbot_active_grant.md
+++ b/docs/tables/turbot_active_grant.md
@@ -1,6 +1,8 @@
 # Table: turbot_active_grant
 
-A active grant is the assignment of a permission to a Turbot user or group on a resource or resource group which is active. 
+An active grant is the assignment of a permission to a Turbot user or group on a resource or resource group which is active.  
+
+The `turbot_active_grant` table will only return active grants.  Use the `turbot_grant` table to get a list of all grants.
 
 ## Examples
 

--- a/go.mod
+++ b/go.mod
@@ -1,21 +1,18 @@
 module github.com/turbot/steampipe-plugin-turbot
 
-go 1.17
+go 1.19
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-yaml/yaml v2.1.0+incompatible
-	github.com/hashicorp/terraform v0.12.0
+	github.com/hashicorp/terraform v0.12.2
 	github.com/machinebox/graphql v0.2.3-0.20180904014615-9835de6386a3
-	github.com/matryer/is v1.4.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	github.com/turbot/go-kit v0.3.0
 	github.com/turbot/steampipe-plugin-sdk v1.8.3
-	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
 require (
@@ -44,6 +41,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/iancoleman/strcase v0.1.2 // indirect
 	github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba // indirect
+	github.com/matryer/is v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mattn/go-runewidth v0.0.7 // indirect
@@ -56,10 +54,12 @@ require (
 	github.com/stevenle/topsort v0.0.0-20130922064739-8130c1d7596b // indirect
 	github.com/tkrajina/go-reflector v0.5.4 // indirect
 	github.com/zclconf/go-cty v1.8.2 // indirect
+	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/sys v0.0.0-20211102061401-a2f17f7b995c // indirect
 	golang.org/x/text v0.3.5 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.41.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/turbot/table_turbot_notification.go
+++ b/turbot/table_turbot_notification.go
@@ -47,7 +47,7 @@ func tableTurbotNotification(ctx context.Context) *plugin.Table {
 			{Name: "icon", Type: proto.ColumnType_STRING, Description: "Icon for this notification type."},
 			{Name: "message", Type: proto.ColumnType_STRING, Description: "Message for the notification."},
 			{Name: "notification_type", Type: proto.ColumnType_STRING, Description: "Type of the notification: resource, action, policySetting, control, grant, activeGrant."},
-			{Name: "create_timestamp", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Turbot.CreateTimestamp"), Description: "When the resource was first discovered by Turbot. (It may have been created earlier.)"},
+			{Name: "create_timestamp", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Turbot.CreateTimestamp"), Description: "When this notification was created."},
 			{Name: "filter", Type: proto.ColumnType_STRING, Transform: transform.FromQual("filter"), Description: "Filter used to search for notifications."},
 
 			// Actor info for the notification
@@ -63,7 +63,7 @@ func tableTurbotNotification(ctx context.Context) *plugin.Table {
 			{Name: "resource_type_id", Type: proto.ColumnType_INT, Transform: transform.FromField("Resource.Type.Turbot.ID").NullIfZero(), Description: "ID of the resource type for this notification."},
 			{Name: "resource_type_uri", Type: proto.ColumnType_STRING, Transform: transform.FromField("Resource.Type.URI"), Description: "URI of the resource type for this notification."},
 			{Name: "resource_type_trunk_title", Type: proto.ColumnType_STRING, Transform: transform.FromField("Resource.Type.Trunk.Title"), Description: "Title of the resource type hierarchy from the root down to this resource."},
-			{Name: "resource_data", Type: proto.ColumnType_JSON, Transform: transform.FromField("Resource.Data"), Description: "The data for this resource"},
+			{Name: "resource_data", Type: proto.ColumnType_JSON, Transform: transform.FromField("Resource.Object"), Description: "The data for this resource at the time of the notification."},
 			{Name: "resource_akas", Type: proto.ColumnType_JSON, Transform: transform.FromField("Resource.Turbot.Akas"), Description: "The globally-unique akas for this resource."},
 			{Name: "resource_parent_id", Type: proto.ColumnType_INT, Transform: transform.FromField("Resource.Turbot.ParentID").NullIfZero(), Description: "The id of the parent resource of this resource."},
 			{Name: "resource_path", Type: proto.ColumnType_STRING, Transform: transform.FromField("Resource.Turbot.Path"), Description: "The string of resource ids separated by \".\" from root down to this resource."},
@@ -161,7 +161,7 @@ const (
 					}
 
 					resource {
-						data
+						object
 						metadata
 						trunk {
 							title
@@ -306,7 +306,7 @@ const (
 					}
 				}
 				resource {
-					data
+					object
 					metadata
 					trunk {
 						title

--- a/turbot/types.go
+++ b/turbot/types.go
@@ -131,7 +131,7 @@ type ControlType struct {
 
 type GrantInfo struct {
 	Grants struct {
-		Items []Grant
+		Items  []Grant
 		Paging struct {
 			Next string
 		}
@@ -445,7 +445,7 @@ type Notification struct {
 	}
 
 	Resource struct {
-		Data     interface{}
+		Object   interface{}
 		Metadata interface{}
 		Type     struct {
 			URI    string


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
This improvement changes the from resources.data to resources.object. The important difference is that `data` always returns the current version resource's data.  Querying for `object` will always return the resource's data at the time of the notification.

```
select create_timestamp, resource_data
from taurus.turbot_notification
where filter = 'resourceId:"arn:aws:s3:::steampipe-turbot-notifications" notificationType:resource'
order by create_timestamp;
```
</details>

You can test against a single resource in a Turbot workspace with a non-trivial change history (something beyond a single `resource_created` notification).  The info in the `resource_data` columns should line up with what appears in the Turbot console.
